### PR TITLE
Connection to API within k8s cluster

### DIFF
--- a/devops/azure-pipelines/helm-template.yml
+++ b/devops/azure-pipelines/helm-template.yml
@@ -38,7 +38,7 @@ jobs:
             image.repository=${{ parameters.repository }}
             imagePullSecrets[0].name=${{ parameters.secretName }}
             image.tag=${{ parameters.imageTag }}
-            deploy.port=3000
+            deploy.port=5000
           arguments: |
             --atomic 
         displayName: 'Helm Deploy'

--- a/devops/docker/Dockerfile
+++ b/devops/docker/Dockerfile
@@ -13,4 +13,8 @@ RUN ["npm", "cache", "clean", "-force"]
 
 RUN ["npm", "install"]
 
-CMD ["npm", "start"]
+RUN ["npm", "run-script", "build"]
+
+RUN ["npm", "install", "-g", "serve"]
+
+CMD ["serve", "-s", "build"]

--- a/devops/helm/forge-frontend/templates/deployment.yaml
+++ b/devops/helm/forge-frontend/templates/deployment.yaml
@@ -39,6 +39,9 @@ spec:
               protocol: TCP
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
+          env:
+            - name: URL_TO_API
+              value: "http://t2backend-forge-backend"
       {{- with .Values.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}

--- a/devops/kube/frontend_manifest.yaml
+++ b/devops/kube/frontend_manifest.yaml
@@ -15,6 +15,9 @@ spec:
       containers:
         - name: forge-frontend
           image: may24devopscontainers.azurecr.io/forge-frontend:latest
+          env:
+            - name: URL_TO_API
+              value: "http://t2backend-forge-backend:80"
           resources:
             requests:
               memory: "500Mi"
@@ -23,7 +26,7 @@ spec:
               memory: "1Gi"
               cpu: "200m"
           ports:
-          - containerPort: 3000
+          - containerPort: 5000
       ImagePullSecrets:
         - name: p3-team2-acr
 
@@ -37,7 +40,7 @@ spec:
   selector:
     app: forge-frontend
   ports:
-    - port: 3000
+    - port: 5000
       name: frontend
       protocol: TCP
 

--- a/src/api/api.ts
+++ b/src/api/api.ts
@@ -1,5 +1,5 @@
 export const url = process.env.NODE_ENV === 'production'
-    ? '/'
+    ? process.env.URL_TO_API
     : 'http://localhost:8081'
 
 export const aboutMeUrl = url + "/aboutMe"

--- a/src/api/api.ts
+++ b/src/api/api.ts
@@ -1,5 +1,5 @@
 export const url = process.env.NODE_ENV === 'production'
-    ? process.env.URL_TO_API
+    ? 'http://t2backend-forge-backend'
     : 'http://localhost:8081'
 
 export const aboutMeUrl = url + "/aboutMe"


### PR DESCRIPTION
The docker container will now contain a built React site and will swap to using a the k8s API end point when deployed.
Serving a built site goes on port 5000 as opposed to the dev which host on 3000.